### PR TITLE
Set hackage revision

### DIFF
--- a/src/ExRender.hs
+++ b/src/ExRender.hs
@@ -98,7 +98,9 @@ instance ExRenderPackage GenericPackageDescription where
             "\""]
 
         pkgDescr = packageDescription descr
-
+        hackageRev = fmap snd
+                       . find (\(k, _) -> k == "x-revision")
+                       $ customFieldsPD pkgDescr
         hasLib = isJust $ condLibrary descr
         hasBin = not . null $ condExecutables descr
         hasMods = maybe False (not . null . exposedModules . condTreeData) . condLibrary $ descr
@@ -112,7 +114,8 @@ instance ExRenderPackage GenericPackageDescription where
                                  "has_hscolour=false",
                                  "has_profile=false"
                                  ]
-                exParams = spaces $ exHasLib <+> exHasBin <+> exHasOptions
+                exHackageRev = maybe empty (\r -> text $ "rev=" ++ r) hackageRev
+                exParams = spaces $ exHasLib <+> exHasBin <+> exHasOptions <+> exHackageRev
 
         exSlot = if not hasBin && hasLib then empty else exField "SLOT" "0"
         exheres = vcat [


### PR DESCRIPTION
This updates the tarball .cabal file with the newer one from
hackage.

Depends on hackage.exlib change:
    https://galileo.mailstation.de/gerrit/#/c/10089/

This is really needed for sanity. There are a lot of packages that would need manual .cabal file patching instead. This conforms to the hackage revision stuff: https://github.com/haskell-infra/hackage-trustees/blob/master/cookbook.md#best-practice-for-managing-meta-data